### PR TITLE
Make the "I don't like it" category let you report an account

### DIFF
--- a/app/javascript/mastodon/features/report/category.js
+++ b/app/javascript/mastodon/features/report/category.js
@@ -42,7 +42,7 @@ class Category extends React.PureComponent {
 
     switch(category) {
     case 'dislike':
-      onNextStep('thanks');
+      onNextStep('statuses');
       break;
     case 'violation':
       onNextStep('rules');


### PR DESCRIPTION
This makes it so that when a user reports an account and selects "I don't like it", instead of getting a message about how they should personally block that person, it sends them to the normal reporting interface and they can file their report.

