### PR TITLE
Revert mztdn 100

### DIFF
--- a/app/javascript/mastodon/features/report/category.jsx
+++ b/app/javascript/mastodon/features/report/category.jsx
@@ -42,7 +42,7 @@ class Category extends React.PureComponent {
 
     switch(category) {
     case 'dislike':
-      onNextStep('statuses');
+      onNextStep('thanks');
       break;
     case 'violation':
       onNextStep('rules');

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -49,7 +49,6 @@ class Report < ApplicationRecord
     other: 0,
     spam: 1_000,
     violation: 2_000,
-    dislike: 3_000
   }
 
   def local?


### PR DESCRIPTION
The admin report UI breaks if there are reports like this, and I see some other places that are likely to break in similar ways. We need to investigate this and integrate it more deeply if we're going to keep this behavior for the `dislike` report.

