### PR TITLE
Mztdn 89/remove mobile sign up button

### DIFF
--- a/app/javascript/mastodon/features/ui/components/header.jsx
+++ b/app/javascript/mastodon/features/ui/components/header.jsx
@@ -58,6 +58,7 @@ class Header extends React.PureComponent {
           </a>
         );
       } else {
+      // eslint-disable-next-line no-unused-vars
         signupButton = (
           <button className='button button-tertiary' onClick={openClosedRegistrationsModal}>
             <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
@@ -68,7 +69,7 @@ class Header extends React.PureComponent {
       content = (
         <>
           <a href='/auth/sign_in' className='button'><FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Sign in' /></a>
-          {signupButton}
+          {/* {signupButton} */}
         </>
       );
     }

--- a/app/javascript/mastodon/features/ui/components/header.jsx
+++ b/app/javascript/mastodon/features/ui/components/header.jsx
@@ -68,7 +68,7 @@ class Header extends React.PureComponent {
 
       content = (
         <>
-          <a href='/auth/sign_in' className='button'><FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Sign in' /></a>
+          <a href='/auth/auth/openid_connect' className='button' rel='nofollow' data-method='post'><FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Sign in' /></a>
           {/* {signupButton} */}
         </>
       );


### PR DESCRIPTION
- removes "sign-up" button from narrow-viewport header
- removes interstitial login page by linking directly to FxA/OIDC login flow