### PR TITLE
Prefer the stored location as after_sign_in_path in Omniauth Callback Controller

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -33,7 +33,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def after_sign_in_path_for(resource)
     if resource.email_present?
-      root_path
+      stored_location_for(resource) || root_path
     else
       auth_setup_path(missing_email: '1')
     end


### PR DESCRIPTION
This is a patch from upstream which fixes a bug where signing in (or creating accounts) using 3rd party Mastodon clients would not redirect back to the client properly.

See the original PR, with linked Issues, here: https://github.com/mastodon/mastodon/pull/24073